### PR TITLE
Make equalize attempt to equalize with minimum possible values

### DIFF
--- a/js/equalize.js
+++ b/js/equalize.js
@@ -30,6 +30,7 @@
           max = 0; // reset for each container
 
       $children.each(function() {
+        $(this).css(equalize,''); //clear previously set value, in order to get the minimum possible.
         var value = $(this)[equalize]();  // call height(), outerHeight(), etc.
         if (value > max) { max = value; } // update max
       });


### PR DESCRIPTION
Hello,

I've added an additional call to css(attribute,''); to clear any existing values before grabbing the element height/width, to allow equalize to reduce height/width where appropriate, rather than just adding to it.

Not 100% sure if this will be useful in all cases, so it may be worth setting a toggle to enable/disable my change if you do decide to include it.

My use case is that i have an app that allows you to move story cards between category's and in order to line them up nicely they need to be the same height. My issue is that once a very tall story card is added to a category (which is then equalized) it causes all other cards to be that height also. The issue then arises once you move a card out of that category in to another, which will cause it to apply its new "tall" height to all of them,  even if no cards in the category are actually tall enough to warrant this.

That said, my usecase is fairly specific so it may not be worth including in your main codebase. I thought i may as well add this pull anyway on the off chance you were interested.

Carl
