### PR TITLE
Add a breakpoint option

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,13 @@ This advanced usage is for dynamic instances where equalize is ran after element
 Equalize the .parent's child element. See @larsbo's <a href="http://jsfiddle.net/4QTNP/3/">example</a>.
 <pre>$('.parent').equalize({children: 'p'}); // equalize height of paragraphs within .parent</pre>
 
+## Breakpoint
+
+This option should be usefull in responsive case where you don't want to equalize elements under a window width breakpoint. It must be used in conjunction with the 'reset' option.
+
+There is little problem in using the window width, that is not the browser screen width used in CSS Media query.
+
+Generally the window width is 15px less larger that the browser screen size because of the vertical scrolling bar. So you should use a breakpoint value less larger than the breakpoint you want to target in your CSS.
 
 ## Examples
 

--- a/README.md
+++ b/README.md
@@ -26,11 +26,11 @@ Equalize the .parent's child element. See @larsbo's <a href="http://jsfiddle.net
 
 ## Breakpoint
 
-This option should be usefull in responsive case where you don't want to equalize elements under a window width breakpoint. It must be used in conjunction with the 'reset' option.
+This option should be usefull in responsive case where you don't want to equalize elements under a viewport width breakpoint. It must be used in conjunction with the 'reset' option.
 
-There is little problem in using the window width, that is not the browser screen width used in CSS Media query.
+<pre>$('.parent').equalize({equalize: 'width', reset: true, breakpoint: 767}); // equalize elements width only if the viewport is larger than 767px</pre>
 
-Generally the window width is 15px less larger that the browser screen size because of the vertical scrolling bar. So you should use a breakpoint value less larger than the breakpoint you want to target in your CSS.
+Note that the method to get the viewport width is not supported for IE8 or less, so we "fallback" to the "clientWidth" that can be different from the viewport, depending if the vertical scrolling is displayed or not.
 
 ## Examples
 
@@ -41,6 +41,9 @@ $('.parent').equalize('width');
 $('.parent').equalize('outerWidth');
 $('.parent').equalize('innerWidth');</pre>
 
+## Safari issue
+
+Safari raise the "ready" jQuery event even if it have not yet downloaded all assets finded in the DOM, so if you try to equalize element that depends from some asset width or height, you should use "equalize.js" in the "load" jQuery event where all assets will be fully downloaded.
 
 # Legal
 

--- a/js/equalize.js
+++ b/js/equalize.js
@@ -28,9 +28,7 @@
  * 
  * BREAKPOINT
  * This option should be usefull in responsive case where you don't want to equalize elements under a window width breakpoint. It must be used in conjunction with the 'reset' option.
- * There is little problem in using the window width, that is not the browser screen width used in CSS Media query. 
- * Generally the window width is 15px less larger that the browser screen size because of the vertical scrolling bar. 
- * So you should use a breakpoint value less larger than the breakpoint you want to target in your CSS.
+ * Note that the method to get the viewport width is not supported for IE8 or less, so we "fallback" to the "clientWidth" that can be different from the viewport, depending if the vertical scrolling is displayed or not.
  */
 ;(function($) {
 
@@ -39,7 +37,7 @@
         children    = false,
         reset       = false,
         breakpoint  = null,
-        win_width   = $(window).innerWidth(),
+        viewport_width   = (window.innerWidth || document.documentElement.clientWidth),
         equalize,
         type;
 
@@ -70,14 +68,14 @@
         if (reset) { $element.css(type, ''); } // remove existing height/width dimension
 
         // Continue if window width is larger than the breakpoint
-        if(!breakpoint || win_width > breakpoint) {
+        if(!breakpoint || viewport_width > breakpoint) {
           value = $element[equalize]();          // call height(), outerHeight(), etc.
           if (value > max) { max = value; }      // update max
         }
       });
 
       // add CSS to children only if window width is larger than the breakpoint
-      if(!breakpoint || win_width > breakpoint) {
+      if(!breakpoint || viewport_width > breakpoint) {
         $children.css(type, max +'px');
       }
     });

--- a/js/equalize.js
+++ b/js/equalize.js
@@ -20,10 +20,17 @@
  * Get the minimum max dimension by removing the existing height/width
  * $('.parent').equalize({reset: true}); // equalize height by default, remove existing height, then determin max
  * $('.parent').equalize({equalize: 'width', reset: true}); // equalize width, remove existing width, then determin max
+ * $('.parent').equalize({equalize: 'width', reset: true, breakpoint: 767}); // same as previous but only if window is larger than 767px
  *
  * Equalize internal child elements
  * From @larsbo : http://jsfiddle.net/4QTNP/3/
  * $('.parent').equalize({children: 'p'}); // equalize height of paragraphs within .parent
+ * 
+ * BREAKPOINT
+ * This option should be usefull in responsive case where you don't want to equalize elements under a window width breakpoint. It must be used in conjunction with the 'reset' option.
+ * There is little problem in using the window width, that is not the browser screen width used in CSS Media query. 
+ * Generally the window width is 15px less larger that the browser screen size because of the vertical scrolling bar. 
+ * So you should use a breakpoint value less larger than the breakpoint you want to target in your CSS.
  */
 ;(function($) {
 
@@ -31,6 +38,8 @@
     var $containers = this, // this is the jQuery object
         children    = false,
         reset       = false,
+        breakpoint  = null,
+        win_width   = $(window).innerWidth(),
         equalize,
         type;
 
@@ -39,12 +48,13 @@
       equalize = options.equalize || 'height';
       children = options.children || false;
       reset    = options.reset || false;
+      breakpoint = options.breakpoint || null;
     } else { // otherwise, a string was passed in or default to height
       equalize = options || 'height';
     }
 
     if (!$.isFunction($.fn[equalize])) { return false; }
-
+    
     // determine if the height or width is being equalized
     type = (equalize.indexOf('eight') > 0) ? 'height' : 'width';
 
@@ -56,12 +66,20 @@
       $children.each(function() {
         var $element = $(this),
             value;
+            
         if (reset) { $element.css(type, ''); } // remove existing height/width dimension
-        value = $element[equalize]();          // call height(), outerHeight(), etc.
-        if (value > max) { max = value; }      // update max
+
+        // Continue if window width is larger than the breakpoint
+        if(!breakpoint || win_width > breakpoint) {
+          value = $element[equalize]();          // call height(), outerHeight(), etc.
+          if (value > max) { max = value; }      // update max
+        }
       });
 
-      $children.css(type, max +'px'); // add CSS to children
+      // add CSS to children only if window width is larger than the breakpoint
+      if(!breakpoint || win_width > breakpoint) {
+        $children.css(type, max +'px');
+      }
     });
   };
 

--- a/js/equalize.min.js
+++ b/js/equalize.min.js
@@ -1,11 +1,1 @@
-/**
- * equalize.js
- * Author & copyright (c) 2012: Tim Svensen
- * Dual MIT & GPL license
- *
- * Page: http://tsvensen.github.com/equalize.js
- * Repo: https://github.com/tsvensen/equalize.js/
- *
- * The jQuery plugin for equalizing the height or width of elements.
- */
-(function(a){a.fn.equalize=function(f){var c=this,e=false,i=false,b=null,h=a(window).innerWidth(),d,g;if(a.isPlainObject(f)){d=f.equalize||"height";e=f.children||false;i=f.reset||false;b=f.breakpoint||null}else{d=f||"height"}if(!a.isFunction(a.fn[d])){return false}g=(d.indexOf("eight")>0)?"height":"width";return c.each(function(){var k=(e)?a(this).find(e):a(this).children(),j=0;k.each(function(){var l=a(this),m;if(i){l.css(g,"")}if(!b||h>b){m=l[d]();if(m>j){j=m}}});if(!b||h>b){k.css(g,j+"px")}})}}(jQuery));
+(function(a){a.fn.equalize=function(g){var d=this,f=false,i=false,b=null,c=(window.innerWidth||document.documentElement.clientWidth),e,h;if(a.isPlainObject(g)){e=g.equalize||"height";f=g.children||false;i=g.reset||false;b=g.breakpoint||null}else{e=g||"height"}if(!a.isFunction(a.fn[e])){return false}h=(e.indexOf("eight")>0)?"height":"width";return d.each(function(){var k=(f)?a(this).find(f):a(this).children(),j=0;k.each(function(){var l=a(this),m;if(i){l.css(h,"")}if(!b||c>b){m=l[e]();if(m>j){j=m}}});if(!b||c>b){k.css(h,j+"px")}})}}(jQuery));

--- a/js/equalize.min.js
+++ b/js/equalize.min.js
@@ -5,5 +5,7 @@
  *
  * Page: http://tsvensen.github.com/equalize.js
  * Repo: https://github.com/tsvensen/equalize.js/
+ *
+ * The jQuery plugin for equalizing the height or width of elements.
  */
-(function(b){b.fn.equalize=function(a){var d=!1,g=!1,c,e;b.isPlainObject(a)?(c=a.equalize||"height",d=a.children||!1,g=a.reset||!1):c=a||"height";if(!b.isFunction(b.fn[c]))return!1;e=0<c.indexOf("eight")?"height":"width";return this.each(function(){var a=d?b(this).find(d):b(this).children(),f=0;a.each(function(){var a=b(this);g&&a.css(e,"");a=a[c]();a>f&&(f=a)});a.css(e,f+"px")})}})(jQuery);
+(function(a){a.fn.equalize=function(f){var c=this,e=false,i=false,b=null,h=a(window).innerWidth(),d,g;if(a.isPlainObject(f)){d=f.equalize||"height";e=f.children||false;i=f.reset||false;b=f.breakpoint||null}else{d=f||"height"}if(!a.isFunction(a.fn[d])){return false}g=(d.indexOf("eight")>0)?"height":"width";return c.each(function(){var k=(e)?a(this).find(e):a(this).children(),j=0;k.each(function(){var l=a(this),m;if(i){l.css(g,"")}if(!b||h>b){m=l[d]();if(m>j){j=m}}});if(!b||h>b){k.css(g,j+"px")}})}}(jQuery));


### PR DESCRIPTION
This add a "breakpoint" option to disable "equalize.js" when the client viewport width is under the value specified in the "breakpoint" option. This is usefull to use "equalize.js" in responsive website.
